### PR TITLE
docs: add digest email testing guide

### DIFF
--- a/docs/features/digest-emails.md
+++ b/docs/features/digest-emails.md
@@ -1,0 +1,54 @@
+# Digest emails
+
+Digest emails summarize recent activity instead of sending one email per event. They are built from event logs and sent by Artisan commands. They are received by employees of organisations or by fund requesters who need to act on recent changes.
+
+## How they work
+
+The digest feature looks for relevant activity since the previous digest timestamp. If no new matching activity exists, the digest command will run successfully without sending any email. If it does find activity it will send the relevant e-mails.
+
+As a side note: The regular test-data seeder creates the baseline data: organizations, funds, providers, products, vouchers, reservations, and fund requests. Outgoing email is disabled while seeding, so those activities are out of scope of the first digest.
+
+## Relevant files and folders
+
+- `backend/app/Digests/` — digest logic per type/audience (`provider_funds`, `requester`, `sponsor`, `validator`, etc.).
+- `backend/app/Console/Commands/Digests/` — Artisan commands that trigger digest sending.
+- `backend/resources/lang/nl/digests.php` — Dutch digest copy (subjects, headings, buttons, body text).
+- `backend/resources/views/emails/mail-builder-template.blade.php` — shared HTML structure for digest rendering.
+- `backend/config/forus/mail_styles.php` — shared mail styles (spacing, typography, buttons, separators).
+
+## Where to change what
+
+- To change digest texts, edit `backend/resources/lang/nl/digests.php`.
+- To change digest event selection or recipient logic, edit the matching class in `backend/app/Digests/`.
+- To change email layout/HTML structure, edit `backend/resources/views/emails/mail-builder-template.blade.php`.
+- To change visual styling or spacing, edit `backend/config/forus/mail_styles.php`.
+- To test output locally, follow `docs/testing/email.md`.
+
+## Digest types
+
+- `provider_funds` — provider fund application, approval, revocation, and sponsor feedback updates.
+- `provider_products` — newly reserved products or services for a provider.
+- `provider_reservations` — reservation status overview for provider products.
+- `requester` — new providers or products available to a requester.
+- `sponsor` — provider applications, product updates, provider messages, and related sponsor work.
+- `sponsor_product_updates` — changed provider products that need sponsor attention.
+- `validator` — new fund requests for validation.
+
+## Triggers
+
+All scheduled digest jobs run at 18:00. Most run daily; `provider_reservations` is the exception and runs weekly on Monday at 18:00. All digest jobs can be triggered manually with Artisan commands, for example when testing locally.
+
+The requester digest exists as a command, but is not enabled in the default scheduler.
+
+## Singular and plural text
+
+Many digest strings use Laravel `trans_choice(...)`. This means the email can show different text for one item and multiple items. When changing digest copy, test both paths when possible:
+
+- one new event to verify singular text;
+- two or more new events to verify plural text.
+
+## Testing
+
+To visually inspect digest emails locally, you can use a tool like Mailpit and create fresh digest events after the baseline seed has run.
+
+See [email testing](../testing/email.md) for the local testing flow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,15 +2,40 @@
 
 Docs for running and contributing to Forus.
 
+For branches, commits, and pull requests, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Getting started
+
 1. [local-setup.md](local-setup.md) — run the backend and frontend.
 2. [seeding-test-data.md](seeding-test-data.md) — seed organizations, funds, and test identities.
 3. [login-and-test-users.md](login-and-test-users.md) — how login works locally, and the dev token shortcut.
+
+## Documentation guidelines
+
+Keep documentation focused on the work at hand. Start with a small, specific .md document when a feature or workflow needs explanation, then restructure later if several related pages grow into a larger topic. Avoid creating broad empty sections upfront.
+
+### Folders
+Use `features/` for product or platform behavior. Use `testing/` for developer workflows that explain how to verify behavior locally.
+
+Use sentence case for headings: capitalize the first word and proper nouns only.
+
+- Keep each page focused on one clear purpose.
+- Prefer practical examples and commands over long theory.
+- Use backticks for file paths, command names, and config keys.
+- Update docs in the same PR when behavior changes.
 
 ## Feature docs
 
 Documentation for specific features lives under `features/`. Add a new file here when a feature needs its own reference.
 
+- [features/digest-emails.md](features/digest-emails.md) — how digest emails collect recent activity and choose singular or plural text.
 - [features/translations.md](features/translations.md) — how webshop translations work, and how to change strings safely.
+
+## Testing docs
+
+Testing documentation lives under `testing/`. Add a new file here when a local verification workflow needs its own reference.
+
+- [testing/email.md](testing/email.md) — how to test outgoing and digest emails locally.
 
 ## Related references
 

--- a/docs/testing/email.md
+++ b/docs/testing/email.md
@@ -47,90 +47,49 @@ Refresh Mailpit and confirm the message appears.
 
 ## Digest email testing
 
-Digest commands only send mail when they find **new** matching activity since each organization’s or fund’s last digest time (see [Digest emails](../features/digest-emails.md)). Running `test-data:seed` fills the database and disables outgoing mail during the seed run; it does not replace the step of adding **fresh** digest-visible activity when you want to preview digests again.
+Digest commands only send mail when they find **new** matching activity since each organization’s or fund’s last digest time (see [Digest emails](../features/digest-emails.md)). Running `test-data:seed` fills the database and disables outgoing mail during the seed run; it does not create ongoing digest-visible activity by itself.
 
-You can create activity by using the product manually (reservations, approvals, and so on), but covering every digest path that way is slow and easy to miss. For local QA, use the `test-data:make-digest-events` command below: it appends digest-oriented EventLog rows on top of an already seeded database. The command does not cover every email path; see [Out of scope](#out-of-scope).
-
-**Prerequisites:** complete [Local setup](../local-setup.md) and [Seeding test data](../seeding-test-data.md) once so baseline organizations, funds, and identities exist. You do not need to re-seed every time you test mail.
+**Prerequisites:** complete [Local setup](../local-setup.md) and [Seeding test data](../seeding-test-data.md) once so baseline organizations, funds, and identities exist.
 
 **Typical flow:**
 
 1. Configure Mailpit and `backend/.env` as in [Local inbox](#local-inbox).
-2. Create fresh digest test events: `php artisan test-data:make-digest-events` (see commands below).
-3. Run the digest Artisan commands.
+2. Use the dashboards (sponsor, provider, requester, validator) to perform real actions that produce the kinds of events described in [Digest emails](../features/digest-emails.md): approvals, reservations, fund requests, provider messages, product updates where applicable, and so on. Repeat or combine actions until you expect a digest run to include something new.
+3. From `backend/`, run the digest Artisan commands you want to inspect (for example `php artisan forus.digest:all`, plus any separate commands mentioned in `backend/app/Console/Commands/Digests/` or your scheduler setup).
 4. Inspect messages in Mailpit.
 
-Create digest events in two modes:
+Digest behaviour depends on selection logic and timestamps; recipient counts and subjects vary with data and locale.
 
-```bash
-php artisan test-data:make-digest-events --mode=singular
-php artisan forus.digest:all
-php artisan forus.digest:provider_reservations
-php artisan forus.sponsor_products_update_digest
+### Singular and plural wording
 
-php artisan test-data:make-digest-events --mode=plural
-php artisan forus.digest:all
-php artisan forus.digest:provider_reservations
-php artisan forus.sponsor_products_update_digest
-```
+Many digest strings use Laravel `trans_choice(...)`. Where it applies, verify singular copy by ensuring only **one** new relevant item sits behind the digest window, and plural copy by creating **two or more** relevant items before running the digest command again.
 
-Use `singular` to create one relevant event per digest type. Use `plural` to create two relevant events per digest type. This lets you verify both `trans_choice(...)` paths.
+### What to check in Mailpit
 
-`forus.digest:all` does not include every digest command. Run `forus.digest:provider_reservations` and `forus.sponsor_products_update_digest` separately when testing all digest email templates.
-
-## What to expect
-
-The command appends activity on top of the existing seeded data. Digest emails are sent to all matching identities and organization employees, so each digest run typically produces several emails per type (one per recipient), not one email total.
-
-Running each mode once on the default seeded dataset produces roughly **25 emails** in Mailpit, with this approximate distribution:
-
-- ~21 requester webshop updates (one per matching identity-fund combination);
-- 2 provider fund updates;
-- 1 provider product reservation update;
-- 1 provider reservations update;
-- 1 sponsor product change update;
-- 1 validator fund request update.
-
-Plural mode produces roughly the same number of emails as singular; what changes is the wording inside each email (`trans_choice` singular versus plural strings), not the recipient count.
-
-Use these emails for visual checks:
+Use rendered emails for visual checks:
 
 - subject and heading text;
-- singular versus plural wording (compare a singular run with a plural run);
+- singular versus plural wording where `trans_choice` applies;
 - general layout and readability;
 - button labels;
 - whether links render as buttons.
 
-## What the command covers
+## Limitations
 
-The `test-data:make-digest-events` command appends EventLog rows for the following digest types:
+Local Mailpit testing does not replace production mail provider behaviour. Coverage depends on which flows you exercise manually; not every digest branch may be reachable without specific seeded data or UI paths.
 
-- `provider_funds` — provider approval (budget) and an individual product approval.
-- `provider_products` — product or service reservation events.
-- `provider_reservations` — reservation status activity.
-- `requester` — new providers approved for a fund.
-- `sponsor` — provider feedback messages (when seeded chats exist).
-- `sponsor_product_updates` — monitored product field changes (only when the sponsor has `allow_product_updates` enabled).
-- `validator` — new fund requests.
+Out of scope for this guide:
 
-## Out of scope
-
-The `test-data:make-digest-events` command is for local visual QA. It does not exhaustively trigger every digest branch.
-
-Out of scope:
-
-- every provider fund sub-state (revoked, sponsor feedback, every individual product combination);
-- sponsor digest subsections that need new `FundProvider` or `Product` rows (pending providers, approved providers, unsubscribed providers, new products);
-- every reservation state;
-- every locale;
+- every digest subsection and edge case;
+- every reservation state and locale;
 - automated assertions on rendered HTML;
-- real email delivery outside Mailpit.
+- delivery beyond your local catcher.
 
 ## Troubleshooting
 
 - **No email in Mailpit** — check `MAIL_HOST`, `MAIL_PORT`, and that Mailpit is running.
-- **Digest command succeeds but sends no email** — there may be no fresh matching events since the last digest timestamp.
-- **Only one text variant appears** — create both singular and plural digest events before running the matching digest commands.
+- **Digest command succeeds but sends no email** — there may be no fresh matching events since the last digest timestamp; perform new qualifying actions and retry.
+- **Only one text variant appears** — adjust how many matching items you create before the digest run so singular versus plural paths can both appear.
 
 ## Related
 

--- a/docs/testing/email.md
+++ b/docs/testing/email.md
@@ -1,0 +1,138 @@
+# Email testing
+
+Use this guide to test outgoing email locally. It explains:
+
+- How testing works: the app still hands messages to SMTP, but you point it at a local inbox instead of a real provider on the public internet.
+- What has to happen for messages to be produced, and how to create that activity for testing.
+- How to open and inspect messages in a testing tool like Mailpit (subject, body text, layout, links).
+
+For how digests choose content, schedules, and where the code lives, see [Digest emails](../features/digest-emails.md).
+
+## Local inbox
+
+For local verification, Mailpit is a simple and safe option: it runs an SMTP server on your machine and shows messages in a browser UI. Nothing is delivered to real inboxes on the internet. For more about Mailpit, see [https://mailpit.axllent.org/](https://mailpit.axllent.org/).
+
+Follow the steps in order: Mailpit must be listening before the backend sends mail; the backend must read your updated mail settings before a test run.
+
+**1. Start Mailpit**
+
+```bash
+docker run -d --name forus-mailpit -p 1025:1025 -p 8025:8025 axllent/mailpit
+```
+
+**2. Point the backend at Mailpit** in `backend/.env`:
+
+```env
+MAIL_DRIVER=smtp
+MAIL_HOST=127.0.0.1
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+```
+
+**3. Pick up `.env` changes** — PHP loads environment values when the process starts. After saving `backend/.env`, restart whatever runs Laravel for you (for example the Docker Compose PHP/backend service, or `php artisan serve` if you use that). One-off `php artisan …` commands start a new process each time and usually see the new values. If mail settings still look stale, run `php artisan config:clear` (in case `config:cache` was used earlier).
+
+**4. Open the inbox** when you want to read messages: `http://127.0.0.1:8025`
+
+## Quick smoke test to check if it works
+
+From `backend/`, send a simple email through Laravel:
+
+```bash
+php artisan tinker --execute='Illuminate\Support\Facades\Mail::raw("Mailpit test from Forus local", function ($m) { $m->to("local-test@example.com")->subject("Forus Mailpit test"); });'
+```
+
+Refresh Mailpit and confirm the message appears.
+
+## Digest email testing
+
+Digest commands only send mail when they find **new** matching activity since each organization’s or fund’s last digest time (see [Digest emails](../features/digest-emails.md)). Running `test-data:seed` fills the database and disables outgoing mail during the seed run; it does not replace the step of adding **fresh** digest-visible activity when you want to preview digests again.
+
+You can create activity by using the product manually (reservations, approvals, and so on), but covering every digest path that way is slow and easy to miss. For local QA, use the `test-data:make-digest-events` command below: it appends digest-oriented EventLog rows on top of an already seeded database. The command does not cover every email path; see [Out of scope](#out-of-scope).
+
+**Prerequisites:** complete [Local setup](../local-setup.md) and [Seeding test data](../seeding-test-data.md) once so baseline organizations, funds, and identities exist. You do not need to re-seed every time you test mail.
+
+**Typical flow:**
+
+1. Configure Mailpit and `backend/.env` as in [Local inbox](#local-inbox).
+2. Create fresh digest test events: `php artisan test-data:make-digest-events` (see commands below).
+3. Run the digest Artisan commands.
+4. Inspect messages in Mailpit.
+
+Create digest events in two modes:
+
+```bash
+php artisan test-data:make-digest-events --mode=singular
+php artisan forus.digest:all
+php artisan forus.digest:provider_reservations
+php artisan forus.sponsor_products_update_digest
+
+php artisan test-data:make-digest-events --mode=plural
+php artisan forus.digest:all
+php artisan forus.digest:provider_reservations
+php artisan forus.sponsor_products_update_digest
+```
+
+Use `singular` to create one relevant event per digest type. Use `plural` to create two relevant events per digest type. This lets you verify both `trans_choice(...)` paths.
+
+`forus.digest:all` does not include every digest command. Run `forus.digest:provider_reservations` and `forus.sponsor_products_update_digest` separately when testing all digest email templates.
+
+## What to expect
+
+The command appends activity on top of the existing seeded data. Digest emails are sent to all matching identities and organization employees, so each digest run typically produces several emails per type (one per recipient), not one email total.
+
+Running each mode once on the default seeded dataset produces roughly **25 emails** in Mailpit, with this approximate distribution:
+
+- ~21 requester webshop updates (one per matching identity-fund combination);
+- 2 provider fund updates;
+- 1 provider product reservation update;
+- 1 provider reservations update;
+- 1 sponsor product change update;
+- 1 validator fund request update.
+
+Plural mode produces roughly the same number of emails as singular; what changes is the wording inside each email (`trans_choice` singular versus plural strings), not the recipient count.
+
+Use these emails for visual checks:
+
+- subject and heading text;
+- singular versus plural wording (compare a singular run with a plural run);
+- general layout and readability;
+- button labels;
+- whether links render as buttons.
+
+## What the command covers
+
+The `test-data:make-digest-events` command appends EventLog rows for the following digest types:
+
+- `provider_funds` — provider approval (budget) and an individual product approval.
+- `provider_products` — product or service reservation events.
+- `provider_reservations` — reservation status activity.
+- `requester` — new providers approved for a fund.
+- `sponsor` — provider feedback messages (when seeded chats exist).
+- `sponsor_product_updates` — monitored product field changes (only when the sponsor has `allow_product_updates` enabled).
+- `validator` — new fund requests.
+
+## Out of scope
+
+The `test-data:make-digest-events` command is for local visual QA. It does not exhaustively trigger every digest branch.
+
+Out of scope:
+
+- every provider fund sub-state (revoked, sponsor feedback, every individual product combination);
+- sponsor digest subsections that need new `FundProvider` or `Product` rows (pending providers, approved providers, unsubscribed providers, new products);
+- every reservation state;
+- every locale;
+- automated assertions on rendered HTML;
+- real email delivery outside Mailpit.
+
+## Troubleshooting
+
+- **No email in Mailpit** — check `MAIL_HOST`, `MAIL_PORT`, and that Mailpit is running.
+- **Digest command succeeds but sends no email** — there may be no fresh matching events since the last digest timestamp.
+- **Only one text variant appears** — create both singular and plural digest events before running the matching digest commands.
+
+## Related
+
+- [Digest emails](../features/digest-emails.md)
+- [Seeding test data](../seeding-test-data.md)


### PR DESCRIPTION
## Summary

Adds documentation for testing outgoing emails locally and explains how digest emails work, so contributors can verify copy and layout changes against Mailpit.

- `docs/testing/email.md` — Mailpit setup, environment configuration, and a digest verification flow based on normal app activity plus the published digest Artisan commands (no extra seed command in `forus-backend`).
- `docs/features/digest-emails.md` — conceptual overview of digest emails, what triggers them, and where the relevant code lives.
- `docs/index.md` — links the new testing and feature pages under Getting started / Documentation guidelines / Testing docs.
- `backend` submodule pointer updated to current `develop`.

## Backend command PR

[teamforus/forus-backend#2869](https://github.com/teamforus/forus-backend/pull/2869) was closed intentionally: that niche Artisan helper does not belong in the backend artefact CI ships. Public docs describe reproducible flows only.

## Test plan

- [x] Read `docs/index.md` and verify the new links resolve.
- [x] Read `docs/testing/email.md` and verify the steps work end-to-end against Mailpit.
- [x] Read `docs/features/digest-emails.md` and verify the linked code paths and translation keys still match the codebase.